### PR TITLE
Urls static

### DIFF
--- a/rpi_csdt_community/settings.py
+++ b/rpi_csdt_community/settings.py
@@ -81,6 +81,7 @@ MEDIA_URL = '/media/'
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'collected_static/')
+STATIC_WEBSITE_ROOT = os.path.join(PROJECT_ROOT, 'static/website/www')
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"

--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -63,5 +63,4 @@ urlpatterns += [
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
     url(r'^(?P<path>.*)$', static.serve, {'document_root':
                                           settings.STATIC_ROOT + "website/www/", }),
-
 ]

--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -62,5 +62,5 @@ urlpatterns += [
     url(r'^media/(?P<path>.*)$', static.serve, {'document_root': settings.MEDIA_ROOT, }),
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
     url(r'^(?P<path>.*)$', static.serve, {'document_root':
-                                          settings.STATIC_ROOT + "website/www/", }),
+                                          settings.STATIC_WEBSITE_ROOT}),
 ]


### PR DESCRIPTION
This updates the catch-all regex at the end of urls.py from /collected_static to just /static, because our static files exist there and aren't collected into collected_static.