### PR TITLE
Regex prefix

### DIFF
--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -63,5 +63,4 @@ urlpatterns += [
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
     url(r'^(?P<path>.*)$', static.serve, {'document_root':
                                           settings.STATIC_ROOT + "website/www/", }),
-
 ]

--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -62,5 +62,5 @@ urlpatterns += [
     url(r'^media/(?P<path>.*)$', static.serve, {'document_root': settings.MEDIA_ROOT, }),
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
     url(r'^culture/(?P<path>.*)$', static.serve, {'document_root':
-                                          settings.STATIC_ROOT + "website/www/", }),
+                                                  settings.STATIC_ROOT + "website/www/", }),
 ]

--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -61,6 +61,6 @@ if settings.ENABLE_GIS:
 urlpatterns += [
     url(r'^media/(?P<path>.*)$', static.serve, {'document_root': settings.MEDIA_ROOT, }),
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
-    url(r'^(?P<path>.*)$', static.serve, {'document_root':
+    url(r'^culture/(?P<path>.*)$', static.serve, {'document_root':
                                           settings.STATIC_ROOT + "website/www/", }),
 ]


### PR DESCRIPTION
Fixing the catchall problem of having ending slashes breaking links and apis by just putting the static pages under the /culture/ prefix.