### PR TITLE
Changing urls.py to use STATIC_WEBSITE_ROOT instead of STATIC_ROOT

### DIFF
--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -65,5 +65,5 @@ urlpatterns += [
     url(r'^media/(?P<path>.*)$', static.serve, {'document_root': settings.MEDIA_ROOT, }),
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
     url(r'^culture/(?P<path>.*)$', static.serve, {'document_root':
-                                                  settings.STATIC_WEBSITE_ROOT }),
+                                                  settings.STATIC_WEBSITE_ROOT}),
 ]

--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -65,5 +65,5 @@ urlpatterns += [
     url(r'^media/(?P<path>.*)$', static.serve, {'document_root': settings.MEDIA_ROOT, }),
     url(r'^static/(?P<path>.*)$', static.serve, {'document_root': settings.STATIC_ROOT, }),
     url(r'^culture/(?P<path>.*)$', static.serve, {'document_root':
-                                                  settings.STATIC_ROOT + "website/www/", }),
+                                                  settings.STATIC_WEBSITE_ROOT }),
 ]


### PR DESCRIPTION
Changes urls.py to use settings.STATIC_WEBSITE_ROOT (which points to static/website/www) instead of settings.STATIC_ROOT (which points to collected_static/)