### PR TITLE
Changes button to full coverage

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -148,3 +148,13 @@ h1 {
 .comment-reply{
     display:none;
 }
+
+.btn-default:hover,
+.btn:focus {
+  text-decoration: none;
+  background-position: 0 -90px;
+  -webkit-transition: background-position 9999s linear;
+  -moz-transition: background-position 9999s linear;
+  -o-transition: background-position 9999s linear;
+  transition: background-position 9999s linear;
+}


### PR DESCRIPTION
There was an error when hovering over the button on the blog only caused the lower half of the button to change color. I couldn't find an easy fix, so I'm using this kind of hacky way to keep the button a single solid color (but it works!)