### PR TITLE
Non-Dry tags->categories

### DIFF
--- a/blogposts/templates/blogposts/filter.html
+++ b/blogposts/templates/blogposts/filter.html
@@ -8,10 +8,10 @@
 <div class="row">
   <div class="col-md-2">
       <p style="height:70px;"></p>
-      Tags:
+      Categories:
       <p>
       {% for tag in view.tags %}
-      <a href="{% url 'blogposts:tag' tag %}">{{tag}}</a>&nbsp
+      <a href="{% url 'blogposts:tag' tag %}">{{tag}}</a><br>
       {% endfor %}
   </div>
   <div class="col-md-8 col-sm-12">

--- a/blogposts/views.py
+++ b/blogposts/views.py
@@ -235,7 +235,7 @@ class ViewTag(ListView):
         return event_dict
 
     def tags(self):
-        return Post.tags.all()
+        return Post.tags.most_common().order_by("rank")
 
 
 class DateSearch(ListView):

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -68,7 +68,7 @@ Linkedin
    <div class='post-detail-item'>{{ instance.get_markdown }}</div>
    <div class="tags" style="font-size: 1.25em;">
      {% if instance.tags %}
-    Tags:&nbsp
+    Categories:&nbsp
     {% for tag in instance.tags.all %}
       <a href="{% url 'blogposts:tag' tag %}">{{ tag }}</a>&nbsp
     {% endfor %}


### PR DESCRIPTION
Since tags search infrastructure is not DRY there are a few stowaways from the renaming of "tags" into "categories" on the main page. Fixes these.