### PR TITLE
Swapping out base.css for blog.css on blog pages

### DIFF
--- a/blogposts/templates/post_detail.html
+++ b/blogposts/templates/post_detail.html
@@ -133,5 +133,5 @@ Linkedin
 {% endblock content %}
 
 {% block css %}
-<link rel="stylesheet" href="{% static 'css/base.css' %}" >
+<link rel="stylesheet" href="{% static 'css/blog.css' %}" >
 {% endblock %}

--- a/blogposts/templates/post_list.html
+++ b/blogposts/templates/post_list.html
@@ -108,7 +108,7 @@
 
 
 {% block css %}
-<link rel="stylesheet" href="{% static 'css/base.css' %}" >
+<link rel="stylesheet" href="{% static 'css/blog.css' %}" >
 {% endblock %}
 
 {% block js %}

--- a/project_share/templates/project_share/application_list.html
+++ b/project_share/templates/project_share/application_list.html
@@ -22,5 +22,13 @@
 {% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="{% static 'css/base.css' %}" >
+<style>
+.application-thumbnail {
+  height: 160px;
+}
+
+.description {
+  display: none;
+}
+</style>
 {% endblock %}

--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -1,0 +1,28 @@
+/* blog css */
+
+h1 {
+    color: #777777;
+}
+
+.wmd-panel{
+    margin-right: 0px !important;
+    margin-left: 0px !important;
+}
+
+.comment-reply{
+    display:none;
+}
+
+.btn-default:hover,
+.btn:focus {
+  text-decoration: none;
+  background-position: 0 -90px;
+  -webkit-transition: background-position 9999s linear;
+  -moz-transition: background-position 9999s linear;
+  -o-transition: background-position 9999s linear;
+  transition: background-position 9999s linear;
+}
+
+.post-detail-item {
+  font-size: 1.35em;
+}


### PR DESCRIPTION
Boots up the font-size on the blog template. Also getting rid of the base.css, which existed for the old bootstrap static cards we had for the home page, which was replaced by the angular menu.