### PR TITLE
Should default to current user now when making a blog post

### DIFF
--- a/blogposts/admin.py
+++ b/blogposts/admin.py
@@ -12,8 +12,12 @@ class PostModelAdmin(admin.ModelAdmin):
     list_display = ["title", "updated", "timestamp", 'tag_list']
     list_display_links = ["updated"]
     list_filter = ["updated", "timestamp"]
-
     search_fields = ["title", "content"]
+
+    def save_model(self, request, obj, form, change):
+        if getattr(obj, 'user', None) is None:
+            obj.user = request.user
+        obj.save()
 
     def get_queryset(self, request):
         return super(PostModelAdmin, self).get_queryset(request).prefetch_related('tags')


### PR DESCRIPTION
As per Bill's request, this should make the "create new blog post" admin panel autofill the current user for the "posted by" field.