### PR TITLE
Buttons are halved

### DIFF
--- a/static/css/csdt.css
+++ b/static/css/csdt.css
@@ -340,6 +340,7 @@ nav .btn {
 
 .btn-default:hover {
   background-position: 0px 0px;
+  background-image: none;
 }
 
 .btn-primary:hover {

--- a/static/css/csdt.css
+++ b/static/css/csdt.css
@@ -330,6 +330,23 @@ nav .btn {
   margin: 0px;
 }
 
+.btn:hover {
+  background-position: 0px 0px;
+}
+
+.btn-info:hover {
+  background-position: 0px 0px;
+}
+
+.btn-default:hover {
+  background-position: 0px 0px;
+}
+
+.btn-primary:hover {
+  background-position: 0px 0px;
+}
+
+
 
 @media only screen and (min-width: 768px) {
     .welcome-container {


### PR DESCRIPTION
![screen shot 2017-08-14 at 10 31 51 am](https://user-images.githubusercontent.com/23264375/29276217-df842144-80db-11e7-85ae-01498080e704.png)

Most buttons on the site are being divided in half based on some bizarre :hover css in the less file. It creates a background-position: 0px -15px; on all hover states.

This overrides that css and makes a background-position: 0px 0px; button hover state.