### PR TITLE
Fixing line length

### DIFF
--- a/rpi_csdt_community/templates/rpi_csdt_community/about.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/about.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-8 col-md-offset-2" style="font-size: 1.3em;">
+    <div class="col-md-10 col-md-offset-1" style="font-size: 1.3em;">
       <h1>About</h1>
       <p>
           <strong>Mission:</strong>

--- a/rpi_csdt_community/templates/rpi_csdt_community/about.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/about.html
@@ -5,20 +5,20 @@
     <div class="col-md-8 col-md-offset-2" style="font-size: 1.3em;">
       <h1>About</h1>
       <p>
-          <b>Mission:</b>
+          <strong>Mission:</strong>
           The mission of the Culturally Situated Design Tools (CSDT) team is to improve education, justice, and equality through new STEM+C educational methods.
       </p>
       <p>
-          <b>Concept:</b>
+          <strong>Concept:</strong>
           By eliminating misconceptions about race and gender in STEM+C, engaging students, and working with teachers, CSDTs can simultaneously teach science, empower students, and change perspectives.
       </p>
       <p>
-          <b>History:</b>
-          CSDTs grew out of the field of Ethomathematics back in 2000. It developed into a series of Java aplets that could be used by teachers in various schools to engage students on math topics.
-          As Java aplets were phased out of use, it was switched to build on <i>Snap!</i> by adding new core components to encorperate culture (CSnap), and expanded to include computer science and general science topics.
+          <strong>History:</strong>
+          CSDTs grew out of the field of Ethomathematics back in 2000. It developed into a series of Java applets that could be used by teachers in various schools to engage students on math topics.
+          As Java applets were phased out of use, it was switched to build on <i>Snap!</i> by adding new core components to incorporate culture (CSnap), and expanded to include computer science and general science topics.
       </p>
       <p>
-          <b>Team:</b>
+          <strong>Team:</strong>
           CSDTs are the brain child of <a href="http://www.sts.rpi.edu/pl/faculty/ron-eglash">Dr. Ron Eglash</a>, professor of Science and Technology Studies at <a href="http://rpi.edu/">Rensselaer Polytechnic Institute</a>, and his Co-PIs:
           <a href="http://www.cm.rpi.edu/pl/people-590/?objectID=516">Professor Audrey Bennet</a>, <a href="http://www.cs.rpi.edu/~moorthy/">Professor Mukkai Krishnamoorthy</a>, <a href="https://www.ecse.rpi.edu/index.php/shayla-sawyer">Professor Shayla Sawyer</a>, and <a href="http://www.cs.rpi.edu/~sibel/SibelAdali/Sibel_Adali.html">Professor Sibel Adali</a>.
           Along with them have been a team of staff, graduate, and undergraduate students. All this has been supported by NSF grants and RPI.

--- a/rpi_csdt_community/templates/rpi_csdt_community/about.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/about.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-10" style="font-size: 1.3em;">
+    <div class="col-md-8 col-md-offset-2" style="font-size: 1.3em;">
       <h1>About</h1>
       <p>
           <b>Mission:</b>


### PR DESCRIPTION
Line length (that the 45th and 75th characters in a sentence shouldn't be on the same line //
http://typographyforlawyers.com/line-length.html) was too long for the About page, and it was also aligned too far to the left, so I made the paragraphs tighter and center aligned.

![screen shot 2017-08-18 at 11 05 11 am](https://user-images.githubusercontent.com/23264375/29464826-2afc9d32-8405-11e7-9108-afe8b0858851.png)