### PR TITLE
project_thumbnail: Stretching image and shrinking height

### DIFF
--- a/templates/_project_thumbnail.html
+++ b/templates/_project_thumbnail.html
@@ -1,12 +1,12 @@
 {% load thumbnail %}
 <div class="col-sm-4 col-md-3">
-    <div class="thumbnail" style="height: 350px; overflow: auto;">
+    <div class="thumbnail" style="height: 320px; overflow: auto;">
     {% if object.approved  or not object.owner == user%}
 	<a href="{% url 'project-detail' pk=object.id %}">
     {% else %}
 	<a href="{% url 'project-update' pk=object.id %}">
     {% endif %}
-        <img src="{% thumbnail object.screenshot.file_path 200x200 crop %}" alt="Screenshot of {{ object.name }}"></a>
+        <img src="{% thumbnail object.screenshot.file_path 200x200 crop %}" alt="Screenshot of {{ object.name }}" width="100%"></a>
          <div class="caption">
             {% if object.approved or not object.owner == user%}
             <a href="{% url 'project-detail' pk=object.id %}">
@@ -15,7 +15,6 @@
             {% endif %}
 			<h4>{{ object.name }}</h4>
 		</a>
-            <p>{{ object.description|truncatewords:10 }}</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Stretches the image in project thumbnail to width of container div. Removes description and shrinks the total height of the card.

I didn't get to test this on a large set of projects, so if there are some outliers that make it break or whatever let me know.

![screen shot 2017-08-18 at 1 20 24 pm](https://user-images.githubusercontent.com/23264375/29469833-0560a9d4-8418-11e7-8c92-98c9ce419627.png)
