### PR TITLE
Overshot it

### DIFF
--- a/templates/_project_thumbnail.html
+++ b/templates/_project_thumbnail.html
@@ -1,6 +1,6 @@
 {% load thumbnail %}
 <div class="col-sm-4 col-md-3">
-    <div class="thumbnail" style="height: 320px; overflow: auto;">
+    <div class="thumbnail" style="height: 340px; overflow: auto;">
     {% if object.approved  or not object.owner == user%}
 	<a href="{% url 'project-detail' pk=object.id %}">
     {% else %}


### PR DESCRIPTION
last update caused some scroll boxes to appear if the name was multi lined.

This should give it enough wiggle room.

changed "320px" to "340px"

![screen shot 2017-08-18 at 1 46 01 pm](https://user-images.githubusercontent.com/23264375/29470785-bbba851c-841b-11e7-8aae-5bec595be1c1.png)
