### PR TITLE
Adds total number of search results, not just paginated 20

### DIFF
--- a/project_share/templates/project_share/project_filter.html
+++ b/project_share/templates/project_share/project_filter.html
@@ -47,7 +47,7 @@
     {% if term or filter_val or order %}
       <p style="padding-left: 20px;font-size: 1.5em;">
         {% if term or filter_val %}
-          ({{ object_list|length }} result{% if not object_list|length == 1 %}s{% endif %})
+          ({{ paginator.count }} result{% if not object_list|length == 1 %}s{% endif %})
         {% endif %}
         {% if term %}
           Search for "{{ term }}"

--- a/project_share/templates/project_share/project_filter.html
+++ b/project_share/templates/project_share/project_filter.html
@@ -47,7 +47,11 @@
     {% if term or filter_val or order %}
       <p style="padding-left: 20px;font-size: 1.5em;">
         {% if term or filter_val %}
-          ({{ paginator.count }} result{% if not paginator.count == 1 %}s{% endif %})
+          {% if paginator %}
+          ({{ paginator.count }} result{% if not paginator.count == 1 %}s{% endif %}
+          {% else %}
+          ({{ object_list|length }} result{% if not object_list|length == 1 %}s{% endif %})
+          {% endif %}
         {% endif %}
         {% if term %}
           Search for "{{ term }}"

--- a/project_share/templates/project_share/project_filter.html
+++ b/project_share/templates/project_share/project_filter.html
@@ -48,7 +48,7 @@
       <p style="padding-left: 20px;font-size: 1.5em;">
         {% if term or filter_val %}
           {% if paginator %}
-          ({{ paginator.count }} result{% if not paginator.count == 1 %}s{% endif %}
+          ({{ paginator.count }} result{% if not paginator.count == 1 %}s{% endif %})
           {% else %}
           ({{ object_list|length }} result{% if not object_list|length == 1 %}s{% endif %})
           {% endif %}

--- a/project_share/templates/project_share/project_filter.html
+++ b/project_share/templates/project_share/project_filter.html
@@ -47,7 +47,7 @@
     {% if term or filter_val or order %}
       <p style="padding-left: 20px;font-size: 1.5em;">
         {% if term or filter_val %}
-          ({{ paginator.count }} result{% if not object_list|length == 1 %}s{% endif %})
+          ({{ paginator.count }} result{% if not paginator.count == 1 %}s{% endif %})
         {% endif %}
         {% if term %}
           Search for "{{ term }}"


### PR DESCRIPTION
Changes the search result parameter to be paginator.count instead of object_list|length because that was just returning "20" multiple times since the results were paginated.
![screen shot 2017-08-18 at 3 19 38 pm](https://user-images.githubusercontent.com/23264375/29474194-aef10ed4-8428-11e7-9c36-a2ee8cf3d21c.png)
