### PR TITLE
Fix for field_label mode_name exists already

### DIFF
--- a/project_share/views.py
+++ b/project_share/views.py
@@ -1,4 +1,5 @@
 """Defines the displays for projects, applications, demos, and goals."""
+from allauth.account.adapter import DefaultAccountAdapter
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.forms import UserChangeForm
@@ -9,6 +10,7 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView, FormView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
@@ -465,3 +467,11 @@ class MyUserChangeForm(UserChangeForm):
     class Meta:
         model = User
         fields = ('email', 'username', 'display_name', 'avatar', 'bio', 'gender', 'race', 'age')
+
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    def __init__(self, request=None):
+        super(CustomAccountAdapter, self).__init__(request)
+        self.error_messages['email_taken'] = _('A user is already registered with this e-mail address.')
+        self.error_messages['username_taken'] = _('A user with that username already exists.')
+        self.error_messages['unique'] = _('A user with that username already exists.')

--- a/rpi_csdt_community/settings.py
+++ b/rpi_csdt_community/settings.py
@@ -347,6 +347,8 @@ WARNING_MESSAGE = "<strong>You are currently looking at the development site!</s
 
 USE_CACHE = False
 
+ACCOUNT_ADAPTER = 'project_share.views.CustomAccountAdapter'
+
 try:
     from local_settings import *  # noqa: F401,F403
 except:


### PR DESCRIPTION
A fix for the "%(field_label) %(model_name)s already exists" error when a username that is already taken is signed up for.

 I was having a hard time in vagrant getting a local_settings.py to work, it caused my build to stop working, so I need this double checked because I couldn't appropriately test it.  Sorry :rage4: 