### PR TITLE
SVG'izes the logo and lightens text, with transitions on hover

### DIFF
--- a/static/css/csdt.css
+++ b/static/css/csdt.css
@@ -1,7 +1,34 @@
 
 
+#svg-logo-color {
+  fill: #d8d8d8;
+  transition: .15s;
+}
+
+.navbar-inverse .navbar-nav>li>a {
+  color: #d8d8d8;
+  transition: .15s;
+}
+
+#svg-box {
+  height: 40px;
+  margin-top: -8px;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.navbar-inverse .navbar-nav>li>a:hover {
+  transition: .25s;
+}
 
 
+
+/* CSDT Logo hover color/animation #661441;*/
+#svg-box:hover #svg-logo-color  {
+    fill: #ffffff;
+    transition: .25s;
+    /* transform: rotate(0.5deg); */
+}
 
 #welcome-logo {
     text-align: center;
@@ -180,6 +207,7 @@
 #toolbar-logo:hover .toolbar-logo-text {
     fill: #ffffff;
 
+
     /* transform: rotate(0.5deg); */
 
 
@@ -268,6 +296,7 @@ nav .btn {
 .navbar-custom .navbar-nav > .active > a, .navbar-nav > .active > a:hover, .navbar-nav > .active > a:focus {
     color: #ffffff;
 	background-color:transparent;
+
 }
 
 /* hover background */

--- a/templates/_nav.html
+++ b/templates/_nav.html
@@ -14,12 +14,50 @@
                       </button>
                       <a class="navbar-brand" href="http://www.nsf.gov"><img style="height: 40px;margin-top: -10px;margin-right:10px;" alt="NSF" src="/static/img/nsf.gif"></a>
 
-                      <a class="navbar-brand" href="{% url 'home' %}"><img style="height: 40px;margin: -10px;" alt="CSDT" src="/static/img/CSDT.LOGO2-SMALL.jpg"></a>
+                      <a class="navbar-brand" href="{% url 'home' %}">
+                        <?xml version="1.0" standalone="no"?>
+                        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+                         "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+                        <svg id="svg-box" version="1.0" xmlns="http://www.w3.org/2000/svg"
+                         width="100px" height="40px" viewBox="0 0 1791.000000 776.000000"
+                         preserveAspectRatio="xMidYMid meet">
+                        <metadata>
+                        Created by potrace 1.15, written by Peter Selinger 2001-2017
+                        </metadata>
+                        <g transform="translate(0.000000,776.000000) scale(0.100000,-0.100000)"
+                        fill="#000000" stroke="none">
+                        <path d="M792 7753 c335 -2 881 -2 1215 0 335 1 61 2 -607 2 -668 0 -942 -1
+                        -608 -2z"/>
+                        <path id="svg-logo-color" d="M2950 7390 l0 -370 -1150 0 -1150 0 0 -3205 0 -3205 3814 0 c2097 0
+                        3828 3 3845 6 l31 7 0 1948 0 1949 -1360 0 -1360 0 0 815 0 815 951 0 952 0
+                        -7 -31 c-3 -17 -6 -130 -6 -250 l0 -219 -85 0 -85 0 0 -80 0 -80 580 0 580 0
+                        0 80 0 80 -85 0 -85 0 0 250 0 250 800 0 800 0 0 -2365 0 -2365 -300 0 -300 0
+                        0 125 0 125 -85 0 -85 0 2 -633 3 -632 83 -3 82 -3 0 85 0 85 968 4 967 3 115
+                        28 c333 81 594 194 861 372 731 488 1164 1314 1284 2449 22 205 31 737 16 902
+                        -65 689 -315 1307 -709 1751 l-64 72 1196 0 1196 0 0 -2730 0 -2729 -97 -3
+                        -98 -3 0 -80 0 -80 578 0 579 0 0 70 c0 39 -1 76 -1 83 -1 8 -25 12 -86 12
+                        l-85 0 0 2750 0 2750 980 0 980 0 0 420 0 420 -6561 0 c-5672 0 -6562 -2
+                        -6575 -14 -12 -13 -14 -253 -14 -1705 l0 -1691 1360 0 1360 0 0 -1080 0 -1080
+                        -962 0 -961 0 6 113 c4 61 7 167 7 234 l0 122 83 3 82 3 0 80 0 80 -577 3
+                        -578 2 0 -85 0 -85 80 0 80 0 0 -235 0 -235 -1630 0 -1630 0 0 2370 0 2370
+                        735 0 735 0 0 -250 0 -250 -80 0 -80 0 0 -80 0 -80 580 0 580 0 0 80 0 80 -84
+                        0 -85 0 2 723 c1 397 -2 860 -7 1030 l-8 307 -409 0 -409 0 0 -370z m8591
+                        -1284 c541 -139 962 -632 1139 -1336 78 -309 104 -545 104 -955 1 -425 -28
+                        -658 -120 -980 -183 -635 -608 -1151 -1131 -1370 l-85 -35 -369 0 -369 0 0
+                        2350 0 2350 369 0 c356 0 371 -1 462 -24z"/>
+                        <path d="M7348 7753 c1806 -2 4758 -2 6560 0 1802 1 325 2 -3283 2 -3608 0
+                        -5083 -1 -3277 -2z"/>
+                        <path d="M2 3763 l-2 -3763 31 0 31 0 -23 19 -24 19 -5 3744 -5 3743 -3 -3762z"/>
+                        </g>
+                        </svg>
+
+
+                      </a>
 
                     </div>
                     <div id="navbar" class="collapse navbar-collapse">
                       <ul class="nav navbar-nav">
-                        <li><a href="{% url 'home' %}">Applications</a></li>
+
                         <li><a href="{% url 'project-list' %}">Projects</a></li>
                         <li><a href="{% url 'team-list' %}">Classrooms</a></li>
                         <li><a href="{% url 'blogposts:list' %}">News</a></li>


### PR DESCRIPTION
Replaces the .jpg logo with an embedded svg logo, which allows hover-over effects. Removes "application" redundant link. Lightens navbar text color to ```#d8d8d8```. 

![screen shot 2018-01-11 at 4 03 53 pm](https://user-images.githubusercontent.com/23264375/34847356-0e5448a4-f6e9-11e7-9ddc-624f3a64eba4.png)
