### PR TITLE
Fixes author's name in blog posts

### DIFF
--- a/blogposts/templates/post_detail.html
+++ b/blogposts/templates/post_detail.html
@@ -31,8 +31,8 @@
 
 
 
-{% if instance.user.get_full_name %}
-<p>Author: {{ instance.user.get_full_name }}</p>
+{% if instance.user %}
+<p>Author: {{ instance.user }}</p>
 {% endif %}
 
 


### PR DESCRIPTION
Adds author's name to blog posts, which Bill requested. It was originally in there, but the code was broken/requested a helper function that didn't exist on the user model.