### PR TITLE
Remove reply

### DIFF
--- a/blogposts/templates/post_detail.html
+++ b/blogposts/templates/post_detail.html
@@ -31,8 +31,8 @@
 
 
 
-{% if instance.user.get_full_name %}
-<p>Author: {{ instance.user.get_full_name }}</p>
+{% if instance.user %}
+<p>Author: {{ instance.user }}</p>
 {% endif %}
 
 

--- a/blogposts/templates/post_detail.html
+++ b/blogposts/templates/post_detail.html
@@ -31,8 +31,8 @@
 
 
 
-{% if instance.user %}
-<p>Author: {{ instance.user }}</p>
+{% if instance.user.get_full_name %}
+<p>Author: {{ instance.user.get_full_name }}</p>
 {% endif %}
 
 
@@ -95,7 +95,7 @@ Linkedin
 
         <blockquote>
           <p>{{ comment.content }}</p>
-          <footer>via {{ comment.user }} | {{ comment.timestamp|timesince }} ago | {% if comment.children.count > 0 %}{{ comment.children.count }} Comment{% if comment.children.count > 1 %}s{% endif %} | {% endif %} <a class='comment-reply-btn' href='#'>Reply</a> | <a class='' href='{{ comment.get_absolute_url }}'>Thread</a></footer>
+          <footer>via {{ comment.user }} | {{ comment.timestamp|timesince }} ago | {% if comment.children.count > 0 %}{{ comment.children.count }} Comment{% if comment.children.count > 1 %}s{% endif %} {% endif %} </footer>
           <div class='comment-reply'>
               {% for child_comment in comment.children %}
                 <blockquote>


### PR DESCRIPTION
Addresses #316 

Just removes the "reply" link from blog comments. I never realized this wasn't implemented (good catch!), and given no one really comments it seems easier just to block thread all replies instead of implementing threading.