### PR TITLE
Adds a few lines for classroom video tutorials on about page

### DIFF
--- a/rpi_csdt_community/templates/rpi_csdt_community/about.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/about.html
@@ -34,6 +34,13 @@
 
         </p>
         <p>
+          <strong>Video Tutorials:</strong>
+          <br>
+          <a href="https://vimeo.com/245028587">Guide On CSDT Classroom Creation</a><br>
+          <a href="https://vimeo.com/245421557">Guide On CSDT Classroom Administration</a><br>
+          <a href="https://vimeo.com/245421728">Guide On How Students Will Use CSDT Classrooms</a>
+        </p>
+        <p>
           <strong>Contact:</strong>
           <br>
           You can contact us at <a href="mailto:csdt@lists.rpi.edu">csdt@lists.rpi.edu</a>.


### PR DESCRIPTION
![screen shot 2018-02-14 at 10 46 19 am](https://user-images.githubusercontent.com/23264375/36213282-50cb91ce-1174-11e8-8a5d-9e0903986dd6.png)

Adds three lines under a "video tutorial" category on the about page. In future we will flesh out a self-standing video tutorial page with many videos, but this is just for now until we make those tutorials.

