### PR TITLE
Clicking a fracexpl project loads it in fracexpl instead of CSnap

### DIFF
--- a/project_share/templates/project_share/SPA-fractal.html
+++ b/project_share/templates/project_share/SPA-fractal.html
@@ -64,9 +64,25 @@
      data-seedlist="3crosses,baila,blanket,bullhorn,cantorpaper,carpet,chaetophora,cnegative,cpositive,davincitree2,davincitree3,davincitree4,dendrite,ethiopian,ethiopian2,fern,fractalspirals,goldenrec,kitwe,koch,kochsmall,logone,lungs,mokoulek,nankani,negative,neuron,positive,queenanne,riverbasin,sierpinski,sprout,turbulence,villi,sharkfin" data-seed="{{pk_num}}"></div>
 
   </div>
-
+  <script>
+      setTimeout(function(){  
+        var btn1 = $("button[title='Regular']");
+        btn1.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button1.png');
+        var btn2 = $("button[title='Flip']");
+        btn2.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button2.png');
+        var btn3 = $("button[title='Invert']");
+        btn3.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button3.png');
+        var btn4 = $("button[title='Invert and Flip']");
+        btn4.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button4.png');
+        var btn5 = $("button[title='Passive Replication']");
+        btn5.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button5.png');
+        var btn4 = $("button[title='Invisible']");
+        btn4.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button6.png');
+      }, 1000);
+    </script>
 
 </body>
+
 
 </html>
 

--- a/project_share/templates/project_share/SPA-fractal.html
+++ b/project_share/templates/project_share/SPA-fractal.html
@@ -65,6 +65,7 @@
 
   </div>
   <script>
+    $( document ).ready(function() {
       setTimeout(function(){  
         var btn1 = $("button[title='Regular']");
         btn1.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button1.png');
@@ -78,7 +79,8 @@
         btn5.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button5.png');
         var btn4 = $("button[title='Invisible']");
         btn4.children('img').attr('src', 'https://dev.csdt.rpi.edu/static/fracexpl/src/button6.png');
-      }, 1000);
+      }, 500);
+    });
     </script>
 
 </body>

--- a/project_share/templates/project_share/SPA-fractal.html
+++ b/project_share/templates/project_share/SPA-fractal.html
@@ -1,0 +1,73 @@
+{% extends "blank.html" %}
+
+{% block content %}
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fractal Simulator</title>
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+  <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <script src = "https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+  <script src="https://csdt.rpi.edu/static/fracexpl/src/FileSaver.min.js"></script>
+  <script src="https://csdt.rpi.edu/static/fracexpl/src/saveToCloud.js"></script>
+  <script src="https://csdt.rpi.edu/static/fracexpl/src/fracexpl.js"></script>
+  <style>
+     .ui-widget-header,.ui-state-default, ui-button {
+        background:#b9cd6d;
+        border: 1px solid #b9cd6d;
+        color: #FFFFFF;
+        font-weight: bold;
+     }
+    #feedback { font-size: 1.4em; }
+    #projectList .ui-selecting { background: #FECA40; }
+    #projectList .ui-selected { background: #F39814; color: white; }
+  </style>
+  <script>
+     $(function() {
+        $( "#projectListDialog" ).dialog({
+           autoOpen: false,
+        });
+      });
+     $(function() {
+        $( "#loginDialog" ).dialog({
+           autoOpen: false,
+        });
+      });
+  </script>
+</head>
+
+<body>
+  <div class="container">
+
+
+    <div id="projectListDialog" title="Select A Project">
+      <ol id="projectList" style="list-style-type: none;">
+      </ol>
+    </div>
+    <div id="loginDialog" title="Login">
+      User Name:
+      <input type="text" name="username"/>
+      <br/>
+      Password:
+      <input type="password" name="password"/>
+    </div>
+    <div style="margin-top: 20px; margin-bottom: 40px;">
+      <span style="font-size: 200%;">Fractal Simulator</span><br/>
+    </div>
+    <div class="fractaltool" data-width="800" data-height="600" data-mode="draw"
+     data-seedlist="3crosses,baila,blanket,bullhorn,cantorpaper,carpet,chaetophora,cnegative,cpositive,davincitree2,davincitree3,davincitree4,dendrite,ethiopian,ethiopian2,fern,fractalspirals,goldenrec,kitwe,koch,kochsmall,logone,lungs,mokoulek,nankani,negative,neuron,positive,queenanne,riverbasin,sierpinski,sprout,turbulence,villi,sharkfin" data-seed="{{pk_num}}"></div>
+
+  </div>
+
+
+</body>
+
+</html>
+
+{% endblock %}

--- a/project_share/templates/project_share/project_detail.html
+++ b/project_share/templates/project_share/project_detail.html
@@ -13,8 +13,12 @@
           {{ object.description }}
         </div>
     </div>
+    {% if object.application == 69 %}
+    <a href="{% url 'fractal-detail' pk=object.pk %}" class="btn btn-large btn-primary">Open</a>
+    {% else %}
     <a href="{% url 'project-run-detail' pk=object.pk %}" class="btn btn-large btn-primary">Open</a>
     <a href="{% url 'project-present-detail' pk=object.pk %}" class="btn btn-large btn-info">Open for Presentation</a>
+    {% endif %}
 	{% if object.owner.id == user.id %}
 		{% if hasApproval %}
 			<a href="{% url 'project-unpublish' pk=object.pk %}" class="btn btn-large btn-primary">Unpublish</a>

--- a/project_share/templates/project_share/project_detail.html
+++ b/project_share/templates/project_share/project_detail.html
@@ -13,8 +13,8 @@
           {{ object.description }}
         </div>
     </div>
-    {% if object.application == 69 %}
-    <a href="{% url 'fractal-detail' pk=object.pk %}" class="btn btn-large btn-primary">Open</a>
+    {% if object.application.id == 69 %}
+    <a href="{% url 'fractal-detail' pk=object.pk %}" class="btn btn-large btn-info">Open</a>
     {% else %}
     <a href="{% url 'project-run-detail' pk=object.pk %}" class="btn btn-large btn-primary">Open</a>
     <a href="{% url 'project-present-detail' pk=object.pk %}" class="btn btn-large btn-info">Open for Presentation</a>

--- a/project_share/urls.py
+++ b/project_share/urls.py
@@ -8,7 +8,7 @@ from project_share.views import (ApplicationDetail, ApplicationList,
                                  ProjectDelete, ProjectDetail, ProjectList,
                                  ProjectPresentDetail, ProjectRunDetail,
                                  ProjectUnpublish, ProjectUpdate,
-                                 UserDetail, ProfileUpdate)
+                                 UserDetail, ProfileUpdate, FractalDetail)
 
 urlpatterns = [
     url(r'^projects/$', ProjectList.as_view(), name='project-list'),
@@ -24,6 +24,8 @@ urlpatterns = [
     url(r'^projects/unpublish/success$',
         TemplateView.as_view(template_name='project_share/project_unpublish_success.html'),
         name='project-unpublish-success'),
+    # individual SPA applications:
+    url(r'^projects/fractal/(?P<pk>\d+)/$', FractalDetail.as_view(), name='fractal-detail'),
 
     url(r'projects/(?P<project_pk>\d+)/publish$', ApprovalCreate.as_view(), name='approval-create'),
     url(r'approval/confirm$', TemplateView.as_view(template_name='project_share/approval_confirm.html'),

--- a/project_share/views.py
+++ b/project_share/views.py
@@ -127,6 +127,7 @@ class ProjectRunDetail(DetailView):
             pass
         return super(ProjectRunDetail, self).render_to_response(context, **response_kwargs)
 
+
 class FractalDetail(TemplateView):
     """Pumps in the project id to the fractal app."""
 
@@ -136,6 +137,7 @@ class FractalDetail(TemplateView):
         context = super(FractalDetail, self).get_context_data(**kwargs)
         context['pk_num'] = self.kwargs['pk']
         return context
+
 
 class ProjectPresentDetail(ProjectRunDetail):
     """Set the project into present (full screen) mode."""

--- a/project_share/views.py
+++ b/project_share/views.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
-from django.views.generic import ListView, FormView
+from django.views.generic import ListView, FormView, TemplateView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django_teams.models import Ownership
@@ -127,6 +127,15 @@ class ProjectRunDetail(DetailView):
             pass
         return super(ProjectRunDetail, self).render_to_response(context, **response_kwargs)
 
+class FractalDetail(TemplateView):
+    """Pumps in the project id to the fractal app."""
+
+    template_name = "project_share/SPA-fractal.html"
+
+    def get_context_data(self, **kwargs):
+        context = super(FractalDetail, self).get_context_data(**kwargs)
+        context['pk_num'] = self.kwargs['pk']
+        return context
 
 class ProjectPresentDetail(ProjectRunDetail):
     """Set the project into present (full screen) mode."""

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -1,0 +1,3 @@
+{% block content %}
+
+{% endblock %}


### PR DESCRIPTION
I'm not the proudest of this engineering. Specifically the fact that we have to duplicate example.html instead of running natively on the /static/fracexpl/src/example.html html and javascript code. But that's the nature of static pages, you can't inject keys and stuff. I hope this works for skateboarder, because I had to use jquery to fix some buttons' broken image links because they used relative links.

[edit] Let me know if you think it would be better to code the software so that it is run off the static url but using a query string to load the project, constructing the url using something like RedirectView (e.g. /static/fracexpl/src/example.html?proj=6039). I'll have to code to check for query strings it in fracexpl, but with project loading already done it should be an easy update.

In fact, I like that so much I'm going to code for it. Closing this.