### PR TITLE
Update about page to include NSF disclaimer

### DIFF
--- a/rpi_csdt_community/templates/rpi_csdt_community/about.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/about.html
@@ -45,6 +45,11 @@
           <br>
           You can contact us at <a href="mailto:csdt@lists.rpi.edu">csdt@lists.rpi.edu</a>.
         </p>
+        <p>
+          <strong>Disclaimer:</strong>
+          <br>
+          This work was supported by the National Science Foundation through NSF grant #1640014. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+        </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a disclaimer about personal views not reflecting those of the NSF onto the About page.

As requested by Bill.