### PR TITLE
Hardcode google analytics in base html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Learn how to program by reading about heritage algorithms from cultures around the world. Then create similar works of art using code in a design simulation.">
     <meta name="keywords" content="learn to program k-12, learn to code k-12, k-12 programming, k-12 coding, k-12 programming tutorial, k-12 coding tutorial, programming lessons, programming tutorials, coding tutorials, learn programming, learn coding, k-12">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1314478-4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-1314478-4');
+    </script>
 
     {% block css %}{% endblock %}
     {% render_block "css" %}
@@ -60,16 +68,7 @@
 
     {% render_block "js" %}
     {% if GOOGLE_ANALYTICS_PROPERTY_ID %}
-        <!-- <script type="text/javascript" src="{% static "js/ga.js" %}"></script> -->
         <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_PROPERTY_ID }}"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', '{{ GOOGLE_ANALYTICS_PROPERTY_ID }}');
-        </script>
     {% endif %}
 
     {% block js %}


### PR DESCRIPTION
Looks like the original way of reading from the settings.py file for the tag is tempermental. So to get it working, I have it hard coded into the base html file. 